### PR TITLE
BUG: Have header keep original rescale slope/intercept values

### DIFF
--- a/include/itkScancoImageIO.h
+++ b/include/itkScancoImageIO.h
@@ -348,6 +348,11 @@ private:
   static void
   PadString(char * dest, const char * source, size_t length);
 
+  /** Rescale the image data to Hounsfield Units */
+  template <typename TBufferType>
+  void
+  RescaleToHU(TBufferType * buffer, size_t size);
+
   void
   InitializeHeader();
 

--- a/src/itkScancoImageIO.cxx
+++ b/src/itkScancoImageIO.cxx
@@ -589,12 +589,6 @@ ScancoImageIO::ReadISQHeader(std::ifstream * file, unsigned long bytesRead)
     }
   }
 
-  // Include conversion to linear att coeff in the rescaling
-  if (this->m_MuScaling > 1.0)
-  {
-    this->m_RescaleSlope /= this->m_MuScaling;
-  }
-
   return 1;
 }
 
@@ -963,12 +957,6 @@ ScancoImageIO::ReadAIMHeader(std::ifstream * file, unsigned long bytesRead)
     h = lineEnd;
   }
 
-  // Include conversion to linear att coeff in the rescaling
-  if (this->m_MuScaling > 1.0)
-  {
-    this->m_RescaleSlope /= this->m_MuScaling;
-  }
-
   // these items are not in the processing log
   this->m_SliceThickness = elementSize[2];
   this->m_SliceIncrement = elementSize[2];
@@ -1017,17 +1005,7 @@ ScancoImageIO::ReadImageInformation()
   }
 
   infile.close();
-
-  // This code causes rescaling to Hounsfield units
-  if (this->m_MuScaling > 1.0 && this->m_MuWater > 0)
-  {
-    // mu(voxel) = intensity(voxel) / m_MuScaling
-    // HU(voxel) = mu(voxel) * 1000/m_MuWater - 1000
-    // Or, HU(voxel) = intensity(voxel) * (1000 / m_MuWater * m_MuScaling) - 1000
-    this->m_RescaleSlope = 1000.0 / (this->m_MuWater * this->m_MuScaling);
-    this->m_RescaleIntercept = -1000.0;
-  }
-
+ 
   this->PopulateMetaDataDictionary();
 }
 
@@ -1135,8 +1113,21 @@ ScancoImageIO::SetHeaderFromMetaDataDictionary()
 
 template <typename TBufferType>
 void
-RescaleToHU(TBufferType * buffer, size_t size, double slope, double intercept)
+ScancoImageIO::RescaleToHU(TBufferType * buffer, size_t size)
 {
+  double slope = this->m_RescaleSlope;
+  double intercept = this->m_RescaleIntercept;
+
+   // This code causes rescaling to Hounsfield units
+  if (this->m_MuScaling > 1.0 && this->m_MuWater > 0)
+  {
+    // mu(voxel) = intensity(voxel) / m_MuScaling
+    // HU(voxel) = mu(voxel) * 1000/m_MuWater - 1000
+    // Or, HU(voxel) = intensity(voxel) * (1000 / m_MuWater * m_MuScaling) - 1000
+    slope = 1000.0 / (this->m_MuWater * this->m_MuScaling);
+    intercept = -1000.0;
+  }
+
   for (size_t i = 0; i < size; i++)
   {
     float bufferValue = static_cast<float>(buffer[i]);
@@ -1322,33 +1313,33 @@ ScancoImageIO::Read(void * buffer)
     switch (dataType)
     {
       case IOComponentEnum::CHAR:
-        RescaleToHU(reinterpret_cast<char *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
+        RescaleToHU(reinterpret_cast<char *>(buffer), bufferSize);
         break;
       case IOComponentEnum::UCHAR:
         RescaleToHU(
-          reinterpret_cast<unsigned char *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
+          reinterpret_cast<unsigned char *>(buffer), bufferSize);
         break;
       case IOComponentEnum::SHORT:
         bufferSize /= 2;
-        RescaleToHU(reinterpret_cast<short *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
+        RescaleToHU(reinterpret_cast<short *>(buffer), bufferSize);
         break;
       case IOComponentEnum::USHORT:
         bufferSize /= 2;
         RescaleToHU(
-          reinterpret_cast<unsigned short *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
+          reinterpret_cast<unsigned short *>(buffer), bufferSize);
         break;
       case IOComponentEnum::INT:
         bufferSize /= 4;
-        RescaleToHU(reinterpret_cast<int *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
+        RescaleToHU(reinterpret_cast<int *>(buffer), bufferSize);
         break;
       case IOComponentEnum::UINT:
         bufferSize /= 4;
         RescaleToHU(
-          reinterpret_cast<unsigned int *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
+          reinterpret_cast<unsigned int *>(buffer), bufferSize);
         break;
       case IOComponentEnum::FLOAT:
         bufferSize /= 4;
-        RescaleToHU(reinterpret_cast<float *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
+        RescaleToHU(reinterpret_cast<float *>(buffer), bufferSize);
         break;
       default:
         itkExceptionMacro("Unrecognized data type in file: " << dataType);

--- a/test/itkScancoImageIOTest2.cxx
+++ b/test/itkScancoImageIOTest2.cxx
@@ -110,13 +110,13 @@ itkScancoImageIOTest2(int argc, char * argv[])
   itk::ExposeMetaData<int>(metaData, "RescaleType", intMeta);
   ITK_TEST_EXPECT_EQUAL(intMeta, 2);
   std::cout << "RescaleSlope: \t\t" << scancoIO->GetRescaleSlope() << std::endl;
-  ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(scancoIO->GetRescaleSlope(), 0.347136, 6, 1e-3));
+  ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(scancoIO->GetRescaleSlope(), 165.9970, 6, 1e-3));
   itk::ExposeMetaData<double>(metaData, "RescaleSlope", doubleMeta);
-  ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(doubleMeta, 0.347136, 6, 1e-3));
+  ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(doubleMeta, 165.9970, 6, 1e-3));
   std::cout << "RescaleIntercept: \t\t" << scancoIO->GetRescaleIntercept() << std::endl;
-  ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(scancoIO->GetRescaleIntercept(), -1000.0, 6, 1e-3));
+  ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(scancoIO->GetRescaleIntercept(), -129.6810, 6, 1e-3));
   itk::ExposeMetaData<double>(metaData, "RescaleIntercept", doubleMeta);
-  ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(doubleMeta, -1000.0, 6, 1e-3));
+  ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(doubleMeta, -129.6810, 6, 1e-3));
   std::cout << "RescaleUnits: \t\t" << scancoIO->GetRescaleUnits() << std::endl;
   ITK_TEST_EXPECT_EQUAL(scancoIO->GetRescaleUnits(), std::string("mg HA/ccm"));
   itk::ExposeMetaData<std::string>(metaData, "RescaleUnits", stringMeta);

--- a/test/itkScancoImageIOTest3.cxx
+++ b/test/itkScancoImageIOTest3.cxx
@@ -84,9 +84,9 @@ itkScancoImageIOTest3(int argc, char * argv[])
   std::cout << "RescaleType: \t\t" << scancoIO->GetRescaleType() << std::endl;
   ITK_TEST_EXPECT_EQUAL(scancoIO->GetRescaleType(), 2);
   std::cout << "RescaleSlope: \t\t" << scancoIO->GetRescaleSlope() << std::endl;
-  ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(scancoIO->GetRescaleSlope(), 0.506726, 6, 1e-3));
+  ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(scancoIO->GetRescaleSlope(), 1603.51904, 6, 1e-3));
   std::cout << "RescaleIntercept: \t\t" << scancoIO->GetRescaleIntercept() << std::endl;
-  ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(scancoIO->GetRescaleIntercept(), -1000.0, 6, 1e-3));
+  ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(scancoIO->GetRescaleIntercept(), -391.209015, 6, 1e-3));
   std::cout << "RescaleUnits: \t\t" << scancoIO->GetRescaleUnits() << std::endl;
   ITK_TEST_EXPECT_EQUAL(scancoIO->GetRescaleUnits(), std::string("mg HA/ccm"));
   std::cout << "CalibrationData: \t\t" << scancoIO->GetCalibrationData() << std::endl;


### PR DESCRIPTION
Relating to [this issue](https://github.com/KitwareMedical/ITKIOScanco/issues/72)

### Issue
The header values for RescaleSlope and RescaleIntercept were being overwritten to convert the image density to HU. This caused a mismatch between original data and output data on write. 

### Proposed Changes:

- Remove overwrite of read in rescale data values in member variables [`m_RescaleSlope`, `m_RescaleIntercept`]
- move HU conversion to inside `RescaleToHU` function
- use `RescaleToHU` as member function which only rescales member data within function scope
- Adjust test cases to match correct `RescaleSlope` and `RescaleIntercept` values

These changes maintain the original header data, and use HU-corrected values only when converting the image data to HU. They also update the header tests to check that the values are maintained as original.

See below for the Scanco read original header values for the test images:

<img width="582" alt="Screenshot 2025-05-26 at 9 31 14 AM" src="https://github.com/user-attachments/assets/af30e30a-9b0c-4e3a-9fcb-d2ecb8686089" />
<img width="582" alt="Screenshot 2025-05-26 at 9 52 36 AM" src="https://github.com/user-attachments/assets/ad8b9e8e-7e80-47fe-a076-8efe2d58acb2" />

