### PR TITLE
Add testing for compressed data

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -115,3 +115,23 @@ itk_add_test(NAME itkScancoImageIOAIM030FloatReadHeader
       0
       "AIMDATA_V030   "
 )
+
+itk_add_test(NAME itkScancoImageIOAIMReadBin
+  COMMAND IOScancoTestDriver
+  --compare
+      DATA{Baseline/AIMIOTestImage.mha}
+      ${ITK_TEST_OUTPUT_DIR}/AIMIOBinUncompressed.aim
+    itkScancoImageIOTest3
+      DATA{Input/AIMIOTestImageBin.AIM}
+      ${ITK_TEST_OUTPUT_DIR}/AIMIOBinUncompressed.aim
+)
+
+itk_add_test(NAME itkScancoImageIOAIMReadRun
+  COMMAND IOScancoTestDriver
+  --compare
+      DATA{Baseline/AIMIOTestImage.mha}
+      ${ITK_TEST_OUTPUT_DIR}/AIMIORunUncompressed.aim
+    itkScancoImageIOTest3
+      DATA{Input/AIMIOTestImageRun.AIM}
+      ${ITK_TEST_OUTPUT_DIR}/AIMIORunUncompressed.aim
+)

--- a/test/Input/AIMIOTestImageBin.AIM.cid
+++ b/test/Input/AIMIOTestImageBin.AIM.cid
@@ -1,0 +1,1 @@
+bafkreiaqiishp2jgb5is5gjx4gmbvnskjed5bzejuthbu2zutaf7xmaehe

--- a/test/Input/AIMIOTestImageRun.AIM.cid
+++ b/test/Input/AIMIOTestImageRun.AIM.cid
@@ -1,0 +1,1 @@
+bafkreiaqiishp2jgb5is5gjx4gmbvnskjed5bzejuthbu2zutaf7xmaehe


### PR DESCRIPTION
### Issue
The infrastructure to decompress aim data on read has existed in the code, but has not been explicitly tested in the testing suite. 

### Changes
- Add image data for both run-length encoded and binary encoded compressed aim images
- The images added are compressed versions of the existing aim test image
- Add tests to read the compressed files and compare their written versions to the original uncompressed data (data is written uncompressed)
- no outward facing API changes are included, only changes to the test suite